### PR TITLE
Reduce the number of dotdeb docker images layers

### DIFF
--- a/jessie-amd64/Dockerfile
+++ b/jessie-amd64/Dockerfile
@@ -5,17 +5,16 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD jessie-amd64.tar /
 
-RUN echo "deb http://http.debian.net/debian/ jessie main contrib non-free" > /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ jessie-updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/ jessie/updates main contrib non-free" >> /etc/apt/sources.list
-
-RUN echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends
-RUN echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends
-
-RUN apt-get update \
+RUN echo "deb http://http.debian.net/debian/ jessie main contrib non-free" > /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ jessie-updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://security.debian.org/ jessie/updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends \
+	&& echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends \
+	&& apt-get update \
 	&& apt-get -y upgrade \
 	&& apt-get -y autoremove \
 	&& apt-get clean \
 	&& find /var/lib/apt/lists -type f -delete
+
 CMD ["/bin/bash"]

--- a/jessie-i386/Dockerfile
+++ b/jessie-i386/Dockerfile
@@ -5,17 +5,16 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD jessie-i386.tar /
 
-RUN echo "deb http://http.debian.net/debian/ jessie main contrib non-free" > /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ jessie-updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/ jessie/updates main contrib non-free" >> /etc/apt/sources.list
-
-RUN echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends
-RUN echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends
-
-RUN apt-get update \
+RUN echo "deb http://http.debian.net/debian/ jessie main contrib non-free" > /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ jessie-updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ jessie-backports main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://security.debian.org/ jessie/updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends \
+	&& echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends \
+	&& apt-get update \
 	&& apt-get -y upgrade \
 	&& apt-get -y autoremove \
 	&& apt-get clean \
 	&& find /var/lib/apt/lists -type f -delete
+
 CMD ["/bin/bash"]

--- a/squeeze-amd64/Dockerfile
+++ b/squeeze-amd64/Dockerfile
@@ -5,18 +5,17 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD squeeze-amd64.tar /
 
-RUN echo "deb http://http.debian.net/debian/ squeeze main contrib non-free" > /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ squeeze-updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ squeeze-lts main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/ squeeze/updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free" >> /etc/apt/sources.list
-
-RUN echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends
-RUN echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends
-
-RUN apt-get update \
+RUN echo "deb http://http.debian.net/debian/ squeeze main contrib non-free" > /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ squeeze-updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ squeeze-lts main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://security.debian.org/ squeeze/updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends \
+	&& echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends \
+	&& apt-get update \
 	&& apt-get -y upgrade \
 	&& apt-get -y autoremove \
 	&& apt-get clean \
 	&& find /var/lib/apt/lists -type f -delete
+
 CMD ["/bin/bash"]

--- a/squeeze-i386/Dockerfile
+++ b/squeeze-i386/Dockerfile
@@ -5,18 +5,17 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD squeeze-i386.tar /
 
-RUN echo "deb http://http.debian.net/debian/ squeeze main contrib non-free" > /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ squeeze-updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ squeeze-lts main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/ squeeze/updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free" >> /etc/apt/sources.list
-
-RUN echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends
-RUN echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends
-
-RUN apt-get update \
+RUN echo "deb http://http.debian.net/debian/ squeeze main contrib non-free" > /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ squeeze-updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ squeeze-lts main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://security.debian.org/ squeeze/updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends \
+	&& echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends \
+	&& apt-get update \
 	&& apt-get -y upgrade \
 	&& apt-get -y autoremove \
 	&& apt-get clean \
 	&& find /var/lib/apt/lists -type f -delete
+
 CMD ["/bin/bash"]

--- a/wheezy-amd64/Dockerfile
+++ b/wheezy-amd64/Dockerfile
@@ -5,17 +5,16 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD wheezy-amd64.tar /
 
-RUN echo "deb http://http.debian.net/debian/ wheezy main contrib non-free" > /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ wheezy-updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ wheezy-backports main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/ wheezy/updates main contrib non-free" >> /etc/apt/sources.list
-
-RUN echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends
-RUN echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends
-
-RUN apt-get update \
+RUN echo "deb http://http.debian.net/debian/ wheezy main contrib non-free" > /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ wheezy-updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ wheezy-backports main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://security.debian.org/ wheezy/updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends \
+	&& echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends \
+	&& apt-get update \
 	&& apt-get -y upgrade \
 	&& apt-get -y autoremove \
 	&& apt-get clean \
 	&& find /var/lib/apt/lists -type f -delete
+
 CMD ["/bin/bash"]

--- a/wheezy-i386/Dockerfile
+++ b/wheezy-i386/Dockerfile
@@ -5,17 +5,16 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD wheezy-i386.tar /
 
-RUN echo "deb http://http.debian.net/debian/ wheezy main contrib non-free" > /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ wheezy-updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://http.debian.net/debian/ wheezy-backports main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://security.debian.org/ wheezy/updates main contrib non-free" >> /etc/apt/sources.list
-
-RUN echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends
-RUN echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends
-
-RUN apt-get update \
+RUN echo "deb http://http.debian.net/debian/ wheezy main contrib non-free" > /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ wheezy-updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://http.debian.net/debian/ wheezy-backports main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://security.debian.org/ wheezy/updates main contrib non-free" >> /etc/apt/sources.list \
+	&& echo "APT::Install-Recommends "false";" > /etc/apt/apt.conf.d/10recommends \
+	&& echo "APT::Install-Suggests "false";" >> /etc/apt/apt.conf.d/10recommends \
+	&& apt-get update \
 	&& apt-get -y upgrade \
 	&& apt-get -y autoremove \
 	&& apt-get clean \
 	&& find /var/lib/apt/lists -type f -delete
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
Hey,

Not really a new feature, i just reduce the number of layer generated when building a image so downloading from docker registry is smaller and faster.

However i do not currently have a debootstrap binary on my hand (mac ...) to ensure that the build is still working (will have it in the coming days). 

